### PR TITLE
[PR-1] SIMULATION TESTED - MAVLab Course Flightplan Bug Fixes and Improvements, and RETREAT Waypoint Added

### DIFF
--- a/conf/airframes/tudelft/bebop_course_orangeavoid.xml
+++ b/conf/airframes/tudelft/bebop_course_orangeavoid.xml
@@ -33,7 +33,7 @@
       <define name="COLOR_OBJECT_DETECTOR_CR_MAX1" value="249"/>
     </target>
     
-    <define name="ARRIVED_AT_WAYPOINT" value="0.5"/><!-- Detect arrival at waypoint when within 0.5m -->
+    <define name="ARRIVED_AT_WAYPOINT" value="0.3"/><!-- Detect arrival at waypoint when within 0.3m -->
 
   <!-- Subsystem section -->
     <module name="telemetry" type="transparent_udp"/>
@@ -271,4 +271,9 @@
     <define name="LOW_BAT_LEVEL" value="11.1" unit="V"/>
     <define name="MAX_BAT_LEVEL" value="12.4" unit="V"/>
   </section>
+  
+  <section name="GCS">
+    <define name="AC_ICON"             value="quadrotor_xi"/>
+  </section>
+
 </airframe>

--- a/conf/flight_plans/tudelft/course_orangeavoid_cyberzoo.xml
+++ b/conf/flight_plans/tudelft/course_orangeavoid_cyberzoo.xml
@@ -46,8 +46,6 @@
       !(nav_block >= IndexOfBlock('land here')) @AND
       (autopilot_in_flight() == true) )" deroute="Standby"/-->
     <!-- Datalink lost (constant RPM descent) -->
-    
-    <!-- CHANGE -->
     <exception cond="((datalink_time @GT 2) @AND 
       !(IndexOfBlock('Holding point') @GT nav_block) @AND
       !(nav_block >= IndexOfBlock('land here')) @AND
@@ -118,7 +116,7 @@
       <call_once fun="NavSetWaypointHere(WP_RETREAT)"/>
       <stay wp="RETREAT"/>
     </block>
-    <block key="l" name="land here" strip_button="land here" strip_icon="land-right.png">
+    <block key="l" name="Land Here" strip_button="Land Here" strip_icon="land-right.png">
       <call_once fun="NavSetWaypointHere(WP_TD)"/>
       <deroute block="Land"/>
     </block>

--- a/conf/flight_plans/tudelft/course_orangeavoid_cyberzoo.xml
+++ b/conf/flight_plans/tudelft/course_orangeavoid_cyberzoo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE flight_plan SYSTEM "../flight_plan.dtd">
-<flight_plan alt="1.0" ground_alt="0" lat0="51.990634" lon0="4.376789" max_dist_from_home="60" name="Bebop avoid orange TU Delft Cyberzoo" security_height="0.4">
+<flight_plan alt="1.0" ground_alt="0" lat0="51.990634" lon0="4.376789" max_dist_from_home="10" name="Bebop avoid orange TU Delft Cyberzoo" security_height="0.4">
   <header>
     #include "modules/datalink/datalink.h"
     #include "modules/energy/electrical.h"
@@ -12,7 +12,7 @@
     <waypoint lat="51.990631" lon="4.376796" name="HOME"/>
     <waypoint name="CLIMB" x="1.9" y="1.0"/>
     <waypoint name="STDBY" x="1.9" y="1.0"/>
-    <waypoint name="TD" x="0.8" y="-1.7"/>
+    <waypoint name="TD" x="0.8" y="-1.7" height="0.5"/>
     <waypoint name="GOAL" x="1.9" y="1.0"/>
     <waypoint name="TRAJECTORY" x="1.9" y="1.0"/>
     <waypoint lat="51.9905834" lon="4.3767710" name="_CZ1"/>
@@ -45,7 +45,9 @@
       !(nav_block >= IndexOfBlock('land here')) @AND
       (autopilot_in_flight() == true) )" deroute="Standby"/-->
     <!-- Datalink lost (constant RPM descent) -->
-    <exception cond="((datalink_time @GT 5) @AND
+    
+    <!-- CHANGE -->
+    <exception cond="((datalink_time @GT 2) @AND 
       !(IndexOfBlock('Holding point') @GT nav_block) @AND
       !(nav_block >= IndexOfBlock('land here')) @AND
       (autopilot_in_flight() == true) )" deroute="land here"/>
@@ -93,6 +95,7 @@
       <call_once fun="NavResurrect()"/>
     </block>
     <block key="t" name="Takeoff" strip_button="Takeoff" strip_icon="takeoff.png">
+      <call_once fun="NavSetWaypointHere(WP_TD)"/> 
       <exception cond="GetPosAlt() @GT 0.8" deroute="Standby"/>
       <call_once fun="NavSetWaypointHere(WP_CLIMB)"/>
       <stay climb="nav.climb_vspeed" vmode="climb" wp="CLIMB"/>
@@ -111,15 +114,15 @@
     </block>
     <block key="l" name="land here" strip_button="land here" strip_icon="land-right.png">
       <call_once fun="NavSetWaypointHere(WP_TD)"/>
-      <go wp="TD"/>
-      <deroute block="Flare"/>
+      <deroute block="Land"/>
     </block>
     <block name="Land">
-      <go wp="TD"/>
+      <exception cond="0.55 @GEQ GetPosAlt()" deroute="Flare"/>
+      <exception cond="block_time @GT 5" deroute="Flare"/>
+      <go wp="TD"/> 
       <deroute block="Flare"/>
     </block>
     <block name="Flare">
-      <exception cond="NavDetectGround()" deroute="Holding point"/>
       <exception cond="!nav_is_in_flight()" deroute="Landed"/>
       <exception cond="0.10 @GT GetPosAlt()" deroute="Landed"/>
       <call_once fun="NavStartDetectGround()"/>

--- a/conf/flight_plans/tudelft/course_orangeavoid_cyberzoo.xml
+++ b/conf/flight_plans/tudelft/course_orangeavoid_cyberzoo.xml
@@ -43,37 +43,37 @@
     <!-- RC lost -->
     <!--exception cond="((radio_control.status == RC_REALLY_LOST) @AND
       !(IndexOfBlock('Holding point') @GT nav_block) @AND
-      !(nav_block >= IndexOfBlock('Land Here')) @AND
+      !(nav_block >= IndexOfBlock('Emergency Landing')) @AND
       (autopilot_in_flight() == true) )" deroute="Standby"/-->
     <!-- Datalink lost (constant RPM descent) -->
     <exception cond="((datalink_time @GT 2) @AND 
       !(IndexOfBlock('Holding point') @GT nav_block) @AND
-      !(nav_block >= IndexOfBlock('Land Here')) @AND
-      (autopilot_in_flight() == true) )" deroute="Land Here"/>
+      !(nav_block >= IndexOfBlock('Emergency Landing')) @AND
+      (autopilot_in_flight() == true) )" deroute="Emergency Landing"/>
     <!-- Geofencing XY -->
     <exception cond="(!InsideCyberZoo(GetPosX(), GetPosY()) @AND
       !(IndexOfBlock('Holding point') @GT nav_block) @AND
-      !(nav_block >= IndexOfBlock('Land Here')) @AND
-      (autopilot_in_flight() == true) )" deroute="Land Here"/>
+      !(nav_block >= IndexOfBlock('Emergency Landing')) @AND
+      (autopilot_in_flight() == true) )" deroute="Emergency Landing"/>
     <!-- Geofencing Z 3.5 -->
     <exception cond="((GetPosAlt() @GT 3.5) @AND
       !(IndexOfBlock('Holding point') @GT nav_block) @AND
-      !(nav_block >= IndexOfBlock('Land Here')) @AND
-      (autopilot_in_flight() == true) )" deroute="Land Here"/>
+      !(nav_block >= IndexOfBlock('Emergency Landing')) @AND
+      (autopilot_in_flight() == true) )" deroute="Emergency Landing"/>
     <!-- Geofencing Z 4.5 (constant RPM descent)-->
     <exception cond="((GetPosAlt() @GT 4.5) @AND
       !(IndexOfBlock('Holding point') @GT nav_block) @AND
-      (autopilot_in_flight() == true) )" deroute="Land Here"/>
+      (autopilot_in_flight() == true) )" deroute="Emergency Landing"/>
     <!-- Bat low -->
     <exception cond="(electrical.bat_low @AND
       !(IndexOfBlock('Holding point') @GT nav_block) @AND
-      !(nav_block >= IndexOfBlock('Land Here')) @AND
-      (autopilot_in_flight() == true) )" deroute="Land Here"/>
+      !(nav_block >= IndexOfBlock('Emergency Landing')) @AND
+      (autopilot_in_flight() == true) )" deroute="Emergency Landing"/>
     <!-- Bat critical (constant RPM no stabilization)-->
     <exception cond="(electrical.bat_critical @AND
       !(IndexOfBlock('Holding point') @GT nav_block) @AND
-      !(nav_block >= IndexOfBlock('Land Here')) @AND
-      (autopilot_in_flight() == true) )" deroute="Land Here"/>
+      !(nav_block >= IndexOfBlock('Emergency Landing')) @AND
+      (autopilot_in_flight() == true) )" deroute="Emergency Landing"/>
   </exceptions>
   <blocks>
     <block name="Wait GPS">
@@ -116,7 +116,7 @@
       <call_once fun="NavSetWaypointHere(WP_RETREAT)"/>
       <stay wp="RETREAT"/>
     </block>
-    <block key="l" name="Land Here" strip_button="Land Here" strip_icon="land-right.png">
+    <block key="l" name="Emergency Landing" strip_button="Emergency Landing" strip_icon="land-right.png">
       <call_once fun="NavSetWaypointHere(WP_TD)"/>
       <deroute block="Land"/>
     </block>

--- a/conf/flight_plans/tudelft/course_orangeavoid_cyberzoo.xml
+++ b/conf/flight_plans/tudelft/course_orangeavoid_cyberzoo.xml
@@ -43,37 +43,37 @@
     <!-- RC lost -->
     <!--exception cond="((radio_control.status == RC_REALLY_LOST) @AND
       !(IndexOfBlock('Holding point') @GT nav_block) @AND
-      !(nav_block >= IndexOfBlock('land here')) @AND
+      !(nav_block >= IndexOfBlock('Land Here')) @AND
       (autopilot_in_flight() == true) )" deroute="Standby"/-->
     <!-- Datalink lost (constant RPM descent) -->
     <exception cond="((datalink_time @GT 2) @AND 
       !(IndexOfBlock('Holding point') @GT nav_block) @AND
-      !(nav_block >= IndexOfBlock('land here')) @AND
-      (autopilot_in_flight() == true) )" deroute="land here"/>
+      !(nav_block >= IndexOfBlock('Land Here')) @AND
+      (autopilot_in_flight() == true) )" deroute="Land Here"/>
     <!-- Geofencing XY -->
     <exception cond="(!InsideCyberZoo(GetPosX(), GetPosY()) @AND
       !(IndexOfBlock('Holding point') @GT nav_block) @AND
-      !(nav_block >= IndexOfBlock('land here')) @AND
-      (autopilot_in_flight() == true) )" deroute="land here"/>
+      !(nav_block >= IndexOfBlock('Land Here')) @AND
+      (autopilot_in_flight() == true) )" deroute="Land Here"/>
     <!-- Geofencing Z 3.5 -->
     <exception cond="((GetPosAlt() @GT 3.5) @AND
       !(IndexOfBlock('Holding point') @GT nav_block) @AND
-      !(nav_block >= IndexOfBlock('land here')) @AND
-      (autopilot_in_flight() == true) )" deroute="land here"/>
+      !(nav_block >= IndexOfBlock('Land Here')) @AND
+      (autopilot_in_flight() == true) )" deroute="Land Here"/>
     <!-- Geofencing Z 4.5 (constant RPM descent)-->
     <exception cond="((GetPosAlt() @GT 4.5) @AND
       !(IndexOfBlock('Holding point') @GT nav_block) @AND
-      (autopilot_in_flight() == true) )" deroute="land here"/>
+      (autopilot_in_flight() == true) )" deroute="Land Here"/>
     <!-- Bat low -->
     <exception cond="(electrical.bat_low @AND
       !(IndexOfBlock('Holding point') @GT nav_block) @AND
-      !(nav_block >= IndexOfBlock('land here')) @AND
-      (autopilot_in_flight() == true) )" deroute="land here"/>
+      !(nav_block >= IndexOfBlock('Land Here')) @AND
+      (autopilot_in_flight() == true) )" deroute="Land Here"/>
     <!-- Bat critical (constant RPM no stabilization)-->
     <exception cond="(electrical.bat_critical @AND
       !(IndexOfBlock('Holding point') @GT nav_block) @AND
-      !(nav_block >= IndexOfBlock('land here')) @AND
-      (autopilot_in_flight() == true) )" deroute="land here"/>
+      !(nav_block >= IndexOfBlock('Land Here')) @AND
+      (autopilot_in_flight() == true) )" deroute="Land Here"/>
   </exceptions>
   <blocks>
     <block name="Wait GPS">

--- a/conf/flight_plans/tudelft/course_orangeavoid_cyberzoo.xml
+++ b/conf/flight_plans/tudelft/course_orangeavoid_cyberzoo.xml
@@ -64,7 +64,7 @@
     <!-- Geofencing Z 4.5 (constant RPM descent)-->
     <exception cond="((GetPosAlt() @GT 4.5) @AND
       !(IndexOfBlock('Holding point') @GT nav_block) @AND
-      (autopilot_in_flight() == true) )" deroute="Landed"/>
+      (autopilot_in_flight() == true) )" deroute="land here"/>
     <!-- Bat low -->
     <exception cond="(electrical.bat_low @AND
       !(IndexOfBlock('Holding point') @GT nav_block) @AND

--- a/conf/flight_plans/tudelft/course_orangeavoid_cyberzoo.xml
+++ b/conf/flight_plans/tudelft/course_orangeavoid_cyberzoo.xml
@@ -15,6 +15,7 @@
     <waypoint name="TD" x="0.8" y="-1.7" height="0.5"/>
     <waypoint name="GOAL" x="1.9" y="1.0"/>
     <waypoint name="TRAJECTORY" x="1.9" y="1.0"/>
+    <waypoint name="RETREAT" x="1.9" y="1.0"/>
     <waypoint lat="51.9905834" lon="4.3767710" name="_CZ1"/>
     <waypoint lat="51.9906440" lon="4.3767060" name="_CZ2"/>
     <waypoint lat="51.9906860" lon="4.3768080" name="_CZ3"/>
@@ -111,6 +112,11 @@
     <block name="STOP">
       <call_once fun="NavSetWaypointHere(WP_STDBY)"/>
       <stay wp="STDBY"/>
+    </block>
+    <block name="RETREAT">
+      <exception cond="block_time @GT 1.8" deroute="STOP"/>
+      <call_once fun="NavSetWaypointHere(WP_RETREAT)"/>
+      <stay wp="RETREAT"/>
     </block>
     <block key="l" name="land here" strip_button="land here" strip_icon="land-right.png">
       <call_once fun="NavSetWaypointHere(WP_TD)"/>

--- a/conf/userconf/tudelft/course_conf.xml
+++ b/conf/userconf/tudelft/course_conf.xml
@@ -7,7 +7,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/tudelft/course_orangeavoid_cyberzoo.xml"
    settings="settings/rotorcraft_basic.xml"
-   settings_modules="modules/ahrs_int_cmpl_quat.xml modules/bebop_cam.xml modules/cv_detect_color_object.xml modules/gps.xml modules/guidance_pid_rotorcraft.xml modules/guidance_rotorcraft.xml modules/imu_common.xml modules/ins_extended.xml modules/nav_rotorcraft.xml modules/orange_avoider.xml modules/stabilization_indi_simple.xml modules/video_capture.xml modules/video_rtp_stream.xml"
+   settings_modules="modules/ahrs_int_cmpl_quat.xml modules/bebop_cam.xml modules/cv_detect_color_object.xml modules/electrical.xml modules/gps.xml modules/guidance_pid_rotorcraft.xml modules/guidance_rotorcraft.xml modules/imu_common.xml modules/ins_extended.xml modules/nav_rotorcraft.xml modules/orange_avoider.xml modules/stabilization_indi_simple.xml modules/video_capture.xml modules/video_rtp_stream.xml"
    gui_color="white"
   />
   <aircraft

--- a/sw/airborne/modules/orange_avoider/orange_avoider.c
+++ b/sw/airborne/modules/orange_avoider/orange_avoider.c
@@ -48,7 +48,7 @@ enum navigation_state_t {
   OBSTACLE_FOUND,
   SEARCH_FOR_SAFE_HEADING,
   OUT_OF_BOUNDS
-};
+  };
 
 // define settings
 float oa_color_count_frac = 0.18f;
@@ -131,12 +131,14 @@ void orange_avoider_periodic(void)
         navigation_state = OBSTACLE_FOUND;
       } else {
         moveWaypointForward(WP_GOAL, moveDistance);
+        moveWaypointForward(WP_RETREAT, -1.0f * moveDistance);
       }
 
       break;
     case OBSTACLE_FOUND:
       // stop
       waypoint_move_here_2d(WP_GOAL);
+      waypoint_move_here_2d(WP_RETREAT);
       waypoint_move_here_2d(WP_TRAJECTORY);
 
       // randomly select new search direction
@@ -156,6 +158,7 @@ void orange_avoider_periodic(void)
     case OUT_OF_BOUNDS:
       increase_nav_heading(heading_increment);
       moveWaypointForward(WP_TRAJECTORY, 1.5f);
+      moveWaypointForward(WP_RETREAT, -1.0f);
 
       if (InsideObstacleZone(WaypointX(WP_TRAJECTORY),WaypointY(WP_TRAJECTORY))){
         // add offset to head back into arena


### PR DESCRIPTION
# Pull Request
### Type of Change
- [x] Bug Fix  
- [x] Feature Update  
- [x] Feature Implementation  
- [ ] Documentation Update  
- [ ] Other (please specify):

### Overview
This pull request introduces several improvements to the MAVLab Course Flightplan (`course_orangeavoid_cyberzoo.xml` ), Airframe (`bebop_course_orangeavoid.xml`), and main code (`orange_avoider.c`), which were tested in simulation and work in simulation. It addresses a critical bug— getting into the "Holding point" block when landing and killing the engines—and improves landing procedures, enhances flight safety by adjusting waypoint arrival criteria, datalink lost behavior, and geofence behavior. Additionally, a new RETREAT waypoint has been implemented, which pulls the Bebop backwards for 1.8 seconds, acting as the inverse of the GOAL waypoint.

### Bug Fix
- Fixed `course_orangeavoid_cyberzoo.xml`: Whenever the Bebop tried to "Land" and then "Takeoff" again, and tried to do a "Emergency Landing" (previously "land here"), it would go into "Holding point" and kill the motors in flight. The logic seemed to be wrong, so this was changed and now it works in simulation. 

### Feature Update
- Updated `course_orangeavoid_cyberzoo.xml`: 
   - Improved the landing procedure for "Land" and "Emergency Landing"; upon "Takeoff" the TD waypoint is set at the point of takeoff at a height of 0.5m. When selecting "Land", the Bebop goes back to the location it took off from, descends to a height of 0.5m and then proceeds to "Flare". Similarly, when selecting "Emergency Landing", the TD waypoint is moved to wherever the Bebop currently is, and then it follows the say procedure as for "Land". 
   - Decreased datalink lost time to 2 seconds instead of 5 seconds. In simulation the drone lands after about 10 seconds after the datalink is lost if the datalink lost time is set to 5 seconds. With the datalink lost time set to 2 seconds, it lands in approx. 4 seconds. 
   - Changed geofence Z 4.5m exception to "Emergency Landing" instead of "Landed", which would kill the motors at an altitude of 4.5m.

- Updated `bebop_course_orangeavoid.xml`: Set the waypoint arrival to 0.3m instead of 0.5m to ensure that only once it is very close to the "Land" block does it "Flare".

### Feature Implementation
- Implemented in `orange_avoider.c` and `course_orangeavoid_cyberzoo.xml`: Added RETREAT waypoint which mimics the movement of the GOAL waypoint but travels behind the Bebop instead of in front. If RETREAT is selected it will move towards the RETREAT waypoint until the block time exceeds 1.8 seconds, essentially a very simple implementation to move the Bebop to a previous position. The simpler the better! ;)

### Documentation Update
- No documentation updates were performed as part of this PR.  

### Reviewer Assistance Requested
- Please take a look at the flightplan and tell me how it looks, if it looks more logical and if the changes made are more logical.
- If you want, test out the RETREAT functionality and let me know what you think.
